### PR TITLE
Feat: Update libraries and packages

### DIFF
--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -33,11 +33,18 @@ RUN apt-get update && \
   python3.8-venv \
   software-properties-common \
   sudo \
-  vim \
   wget \
   xdot \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 RUN add-apt-repository -y ppa:ethereum/ethereum && \
   apt-get update && \

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh node solc python jq curl vim wget"
+required_packages="gh node solc python jq curl nvim wget"
 
 for exec in $required_packages;
 do


### PR DESCRIPTION
- Replace 'vim' with 'nvim'. This is done because 'nvim' also acts as a
  server for vscode.
- Update `devcontainer-checks.sh` to check for 'vim' instead of 'vim'.
