### PR TITLE
Fix: solc-select not working

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "**.**.**"
-      - feature/**/**
       - experiment/**/**/**
     paths:
       - src/**
@@ -35,34 +34,29 @@ jobs:
             src/**
             .github/workflows/build-and-push.yml
 
-      - name: Get latest tag
-        id: latest_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
-        with:
-          fallback: tag-unavailable
-
       - name: Declare run state
         id: run-state
         run: |
-          if [ ${{ steps.latest_tag.outputs.tag }} != tag-unavailable ] && \
+          if [ ${{ github.ref_type }} == tag ] && \
             ( \
               [ ${{ steps.changed_files.outputs.any_modified }} == true ] || \
               [ ${{ github.event_name }} == workflow_dispatch ] \
             );
           then
-            echo "::set-output name=run_docker_build::true"
+            echo "run_docker_build=true" >> $GITHUB_OUTPUT
             echo "::debug::Docker build will carry out as expected."
           else
-            echo "::set-output name=run_docker_build::false"
-            echo "::debug::Docker build is cancelled as none of the watched files have been changed."
-            echo "Docker build is cancelled as none of the watched files have been changed."
+            cancel_message="Docker build is cancelled as build requirements haven't been met."
+            echo "run_docker_build=false" >> $GITHUB_OUTPUT
+            echo "::debug::$cancel_message"
+            echo "$cancel_message"
           fi
 
       - name: Variables
         id: variables
         run: |
           image_name=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.CONTAINER_NAME }}
-          repo_tag=${{ steps.latest_tag.outputs.tag }}
+          repo_tag=${{ github.ref_name }}
           image_tag=${repo_tag//\//-}
           dev_image_tag=${image_tag}
           image_ref="${image_name}:${image_tag}"
@@ -70,13 +64,17 @@ jobs:
           short_image_ref="${{ env.CONTAINER_NAME }}:${image_tag}"
           short_dev_image_ref="${{ env.CONTAINER_NAME }}:${dev_image_tag}"
 
-          echo "::set-output name=image_name::$image_name"
-          echo "::set-output name=image_tag::$image_tag"
-          echo "::set-output name=dev_image_tag::$dev_image_tag"
-          echo "::set-output name=image_ref::$image_ref"
-          echo "::set-output name=dev_image_ref::$dev_image_ref"
-          echo "::set-output name=short_image_ref::$short_image_ref"
-          echo "::set-output name=short_dev_image_ref::$short_dev_image_ref"
+          for i in \
+            image_name \
+            image_tag \
+            dev_image_tag \
+            image_ref \
+            dev_image_ref \
+            short_image_ref \
+            short_dev_image_ref; 
+          do 
+            echo "$i=${!i}" >> $GITHUB_OUTPUT; 
+          done
 
       - name: Set up Docker Buildx
         if: steps.run-state.outputs.run_docker_build == 'true'

--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -68,6 +68,7 @@ ENV PATH="$VIRTUAL_ENV_PATH_MYTHRIL/bin:$PATH"
 COPY src/requirements.mythril.txt .
 RUN source $VIRTUAL_ENV_PATH_MYTHRIL/bin/activate
 RUN pip install -r requirements.mythril.txt --no-input --no-cache-dir
+RUN chown -R 1000:1000 $VIRTUAL_ENV_PATH_MYTHRIL
 
 ENV VIRTUAL_ENV_PATH_SLITHER=/opt/venv/slither
 RUN python3 -m venv $VIRTUAL_ENV_PATH_SLITHER
@@ -75,6 +76,7 @@ ENV PATH="$VIRTUAL_ENV_PATH_SLITHER/bin:$PATH"
 COPY src/requirements.slither.txt .
 RUN source $VIRTUAL_ENV_PATH_SLITHER/bin/activate
 RUN pip install -r requirements.slither.txt --no-input --no-cache-dir
+RUN chown -R 1000:1000 $VIRTUAL_ENV_PATH_SLITHER
 
 RUN cd $VIRTUAL_ENV_PATH_SLITHER/bin && \
   wget https://github.com/crytic/echidna/releases/download/v2.0.0/echidna-test-2.0.0-Ubuntu-18.04.tar.gz \


### PR DESCRIPTION
- Close #5 by making sure that 'venv' subfolders belong to the container
  user.
- Update github workflow `build-and-push` output setting syntax as the
  old syntax that uses `set-output` is to be deprecated soon.
- Remove action `latest_tag` as its function can easily be replicated by
  using `github.ref_type` and `github.ref_name`.
