### PR TITLE
Feat: Separate venv for manticore

### DIFF
--- a/src/Dockerfile.dev
+++ b/src/Dockerfile.dev
@@ -78,6 +78,14 @@ RUN source $VIRTUAL_ENV_PATH_SLITHER/bin/activate
 RUN pip install -r requirements.slither.txt --no-input --no-cache-dir
 RUN chown -R 1000:1000 $VIRTUAL_ENV_PATH_SLITHER
 
+ENV VIRTUAL_ENV_PATH_MANTICORE=/opt/venv/manticore
+RUN python3 -m venv $VIRTUAL_ENV_PATH_MANTICORE
+ENV PATH="$VIRTUAL_ENV_PATH_MANTICORE/bin:$PATH"
+COPY src/requirements.manticore.txt .
+RUN source $VIRTUAL_ENV_PATH_MANTICORE/bin/activate
+RUN pip install -r requirements.manticore.txt --no-input --no-cache-dir
+RUN chown -R 1000:1000 $VIRTUAL_ENV_PATH_MANTICORE
+
 RUN cd $VIRTUAL_ENV_PATH_SLITHER/bin && \
   wget https://github.com/crytic/echidna/releases/download/v2.0.0/echidna-test-2.0.0-Ubuntu-18.04.tar.gz \
   -O echidna.tar.gz \

--- a/src/requirements.manticore.txt
+++ b/src/requirements.manticore.txt
@@ -1,0 +1,4 @@
+crytic-compile==0.2.2
+protobuf==3.20.*
+manticore[native] 
+solc-select


### PR DESCRIPTION
- Add a new python environment for manticore. This is done because
  manticore uses protobuf and crytic-complile versions that aren't
  supported by other tools, such as slither.
